### PR TITLE
Fixed Markdown section link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Diese Repo soll es erm&ouml;glichen Informationen &uuml;ber lokale Warnmeldungen
 
 ## Zugriff mit curl
 
-Eine Liste aller Lokationen sind [hier](#Landkreise%20und%20Regionen) zu finden.
+Eine Liste aller Lokationen sind [hier](#Landkreise-und-Regionen) zu finden.
 
 ```
 location={insertLocationHere}


### PR DESCRIPTION
The link to the region list within the readme.md didn't work before, because spaces must be replaced by dashes there. Fixed that for you